### PR TITLE
Fix main 'vg-ima-ads.js' in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "videogular-ima-ads",
   "version": "1.0.0",
-  "main": "./ima-ads.js",
+  "main": "./vg-ima-ads.js",
   "dependencies": {
     "videogular": "latest"
   }


### PR DESCRIPTION
The Wiredep can not add files, because of the wrong file name in the mian bower.json
